### PR TITLE
fix: update type definition of updateLastAssistantMessage

### DIFF
--- a/store/admin/useThreadsStore.ts
+++ b/store/admin/useThreadsStore.ts
@@ -15,7 +15,7 @@ interface ThreadsState {
   setCurrentThreadId: (id: string | null) => void;
   setMessages: (messages: Message[]) => void;
   addMessage: (message: Message) => void;
-  updateLastAssistantMessage: (content: string) => void;
+  updateLastAssistantMessage: (content: string, role?: 'assistant' | 'image') => void;
   setLoading: (loading: boolean) => void;
   setSending: (sending: boolean) => void;
   


### PR DESCRIPTION
This PR fixes a TypeScript compilation error in ChatInterface.tsx where updateLastAssistantMessage was called with 2 arguments but only defined for 1. The store interface is now updated to accept an optional 'role' parameter.

Resolves #19