### PR TITLE
chore: add agent rules to forbid direct pushes

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,17 @@
+# Project: nischaysharma-client
+
+## Agent Rules
+1. Whenever you are done with a task, commit the changes locally.
+2. Follow the BEM methodology for all SASS styling.
+
+## Push Rules
+1. **NEVER** push to `main`, `master`, or `develop` branches directly.
+2. All changes **MUST** be made in a feature branch and submitted via a Pull Request.
+3. No exceptions for any reason (fixes, docs, etc.).
+
+## Branching Strategy
+1. New branches should follow the pattern: `<username>/<feature-name>`
+2. Push feature branches to the remote for PR creation.
+
+## COMMIT RULES
+1. Commit messages must follow the format: `feat()/fix()/refactor()/docs()/style()/test()/chore(): <message>`


### PR DESCRIPTION
This PR adds the GEMINI.md file to strictly forbid direct pushes to main and develop branches.